### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "DOM"
   ],
   "dependencies": {
-    "babel-preset-es2015": "^6.6.0",
-    "babelify": "^7.3.0",
     "brisky-core": "^1.5.0"
   },
   "browserify": {


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that 2 of the runtime dependencies is installed, however, they are not used during the test runtime. We removed these dependencies from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?